### PR TITLE
Adds tasks that runs vault schema

### DIFF
--- a/ansible-vault/roles/postgresql/tasks/main.yml
+++ b/ansible-vault/roles/postgresql/tasks/main.yml
@@ -53,7 +53,6 @@
     users: "vault"
     databases: "vault"
     method: "md5"
-    method: "password"
   become: true
   notify:
     - "Reload postgresql service"
@@ -70,9 +69,8 @@
   tags: "postgresql"
 
 - name: "Execute vault schema"
-  postgresql_script:
-    db: "vault"
-    path: "{{ schema_path_dest }}/vault_schema.sql"
+  shell:
+    command: "psql --dbname=vault --file={{ schema_path_dest }}/vault_schema.sql --no-password"
   become: true
   become_user: "postgres"
   tags: "postgresql"


### PR DESCRIPTION
To use the postgresql server, according to the documentation there is a need to run a SQL script that creates a table and a index in the database